### PR TITLE
SEBSERV-715 exam template wizard: validation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,7 +27,7 @@
                 "vue-i18n": "^9.13.1",
                 "vue-loading-overlay": "^6.0.4",
                 "vue-router": "^4.4.0",
-                "vuetify": "^3.8.7",
+                "vuetify": "3.10.4",
                 "webfontloader": "^1.6.28"
             },
             "devDependencies": {
@@ -5017,12 +5017,9 @@
             }
         },
         "node_modules/vuetify": {
-            "version": "3.8.7",
-            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.8.7.tgz",
-            "integrity": "sha512-Xid5za36cOA9We0QShcjiI4qoWXcwABhlhDHi8/0qpjSrBgJ63GobQdZ9YYyRvjMT3XXJqgbkdis1RS/oGL8Bw==",
-            "engines": {
-                "node": "^12.20 || >=14.13"
-            },
+            "version": "3.10.4",
+            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.10.4.tgz",
+            "integrity": "sha512-aatUQ0RM0i6VdkJaFyj3gydecuFmAgACNO3RwWznvjvIvRENQXxMRiv+vlGFoshbw2UG+zOPPMhO12OCPSa2UQ==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/johnleider"

--- a/client/package.json
+++ b/client/package.json
@@ -48,7 +48,7 @@
         "vue-i18n": "^9.13.1",
         "vue-loading-overlay": "^6.0.4",
         "vue-router": "^4.4.0",
-        "vuetify": "^3.8.7",
+        "vuetify": "3.10.4",
         "webfontloader": "^1.6.28"
     },
     "devDependencies": {

--- a/client/src/components/views/seb-server/template/exam/components/stepNaming/StepNaming.vue
+++ b/client/src/components/views/seb-server/template/exam/components/stepNaming/StepNaming.vue
@@ -4,14 +4,14 @@
             :title="$t('createTemplateExam.steps.naming.title')"
             :subtitle="$t('createTemplateExam.steps.naming.subtitle')"
         >
-            <Form :fields="formFields" />
+            <Form v-model="useStepNamingStore().isReady" :fields="formFields" />
         </Step>
     </LoadingFallbackComponent>
 </template>
 
 <script setup lang="ts">
 import { useFormFields } from "./composables/useFormFields";
+import { useStepNamingStore } from "./composables/store/useStepNamingStore";
 
-// TODO @alain: "isReady" of the step should be based on the form being valid
 const { formFields, loading, errors } = useFormFields();
 </script>

--- a/client/src/components/views/seb-server/template/exam/components/stepNaming/StepNaming.vue
+++ b/client/src/components/views/seb-server/template/exam/components/stepNaming/StepNaming.vue
@@ -12,7 +12,6 @@
 <script setup lang="ts">
 import { useFormFields } from "./composables/useFormFields";
 
-// TODO @alain: deal with validation
 // TODO @alain: "isReady" of the step should be based on the form being valid
 const { formFields, loading, errors } = useFormFields();
 </script>

--- a/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/api/useExamTemplateNames.ts
+++ b/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/api/useExamTemplateNames.ts
@@ -1,0 +1,5 @@
+import { useFetch } from "@/composables/useFetch";
+import { getExamTemplateNames } from "@/services/seb-server/api-services/examTemplateService";
+
+export const useExamTemplateNames = () =>
+    useFetch(() => getExamTemplateNames());

--- a/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/store/useStepNamingStore.ts
+++ b/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/store/useStepNamingStore.ts
@@ -1,8 +1,9 @@
 import { ExamTypeEnum } from "@/models/seb-server/examFiltersEnum";
 import { defineStore } from "pinia";
-import { ref, computed } from "vue";
+import { ref } from "vue";
 
 const initialState = {
+    isReady: false,
     name: "",
     description: "",
     examType: ExamTypeEnum.UNDEFINED,
@@ -13,6 +14,7 @@ const initialState = {
 };
 
 export const useStepNamingStore = defineStore("stepNaming", () => {
+    const isReady = ref(initialState.isReady);
     const name = ref(initialState.name);
     const description = ref(initialState.description);
     const examType = ref<ExamTypeEnum>(initialState.examType);
@@ -27,11 +29,8 @@ export const useStepNamingStore = defineStore("stepNaming", () => {
         initialState.institutionalDefault,
     );
 
-    const isReady = computed(() => {
-        return name.value.length > 0;
-    });
-
     const $reset = () => {
+        isReady.value = initialState.isReady;
         name.value = initialState.name;
         description.value = initialState.description;
         examType.value = initialState.examType;

--- a/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/useFormFields.ts
+++ b/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/useFormFields.ts
@@ -6,6 +6,7 @@ import { useClientConfigurationNames } from "./api/useClientConfigurationNames";
 import { useConfigurationTemplateNames } from "./api/useConfigurationTemplateNames";
 import { storeToRefs } from "pinia";
 import { useStepNamingStore } from "./store/useStepNamingStore";
+import { useRules } from "vuetify/labs/rules";
 
 export const useFormFields = () => {
     const { t } = useI18n();
@@ -60,6 +61,7 @@ export const useFormFields = () => {
                     "createTemplateExam.steps.naming.fields.name.placeholder",
                 ),
                 required: true,
+                rules: [useRules().minLength(3)],
             },
             {
                 type: "textarea" as const,

--- a/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/useFormFields.ts
+++ b/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/useFormFields.ts
@@ -2,6 +2,7 @@ import { useI18n } from "vue-i18n";
 import { computed } from "vue";
 import { FormField } from "@/components/widgets/form/types";
 import { ExamTypeEnum } from "@/models/seb-server/examFiltersEnum";
+import { useExamTemplateNames } from "./api/useExamTemplateNames";
 import { useClientConfigurationNames } from "./api/useClientConfigurationNames";
 import { useConfigurationTemplateNames } from "./api/useConfigurationTemplateNames";
 import { storeToRefs } from "pinia";
@@ -22,6 +23,12 @@ export const useFormFields = () => {
     } = storeToRefs(useStepNamingStore());
 
     const {
+        data: examTemplateNames,
+        loading: loadingExamTemplateNames,
+        error: errorExamTemplateNames,
+    } = useExamTemplateNames();
+
+    const {
         data: configurationTemplateNames,
         loading: loadingConfigurationTemplateNames,
         error: errorConfigurationTemplateNames,
@@ -35,12 +42,14 @@ export const useFormFields = () => {
 
     const loading = computed(
         () =>
+            loadingExamTemplateNames.value ||
             loadingConfigurationTemplateNames.value ||
             loadingClientConfigurationNames.value,
     );
 
     const errors = computed(() =>
         [
+            errorExamTemplateNames.value,
             errorConfigurationTemplateNames.value,
             errorClientConfigurationNames.value,
         ].filter((error) => error !== undefined),
@@ -65,7 +74,11 @@ export const useFormFields = () => {
                     useRules().minLength(3),
                     useRules().maxLength(255),
                     useRules().blacklisted(
-                        new Set(["Test", "Foo", "Bar"]), // TODO @alain: use values from API here
+                        new Set(
+                            examTemplateNames.value?.map(
+                                (examTemplate) => examTemplate.name,
+                            ) ?? [],
+                        ),
                         t(
                             "createTemplateExam.steps.naming.fields.name.validationErrorUniqueName",
                         ),

--- a/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/useFormFields.ts
+++ b/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/useFormFields.ts
@@ -61,7 +61,7 @@ export const useFormFields = () => {
                     "createTemplateExam.steps.naming.fields.name.placeholder",
                 ),
                 required: true,
-                rules: [useRules().minLength(3)],
+                rules: [useRules().minLength(3), useRules().maxLength(255)],
             },
             {
                 type: "textarea" as const,
@@ -73,6 +73,7 @@ export const useFormFields = () => {
                 placeholder: t(
                     "createTemplateExam.steps.naming.fields.description.placeholder",
                 ),
+                rules: [useRules().maxLength(4000)],
             },
             {
                 type: "select" as const,

--- a/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/useFormFields.ts
+++ b/client/src/components/views/seb-server/template/exam/components/stepNaming/composables/useFormFields.ts
@@ -61,7 +61,16 @@ export const useFormFields = () => {
                     "createTemplateExam.steps.naming.fields.name.placeholder",
                 ),
                 required: true,
-                rules: [useRules().minLength(3), useRules().maxLength(255)],
+                rules: [
+                    useRules().minLength(3),
+                    useRules().maxLength(255),
+                    useRules().blacklisted(
+                        new Set(["Test", "Foo", "Bar"]), // TODO @alain: use values from API here
+                        t(
+                            "createTemplateExam.steps.naming.fields.name.validationErrorUniqueName",
+                        ),
+                    ),
+                ],
             },
             {
                 type: "textarea" as const,

--- a/client/src/components/views/seb-server/template/exam/components/stepSupervisors/StepSupervisors.vue
+++ b/client/src/components/views/seb-server/template/exam/components/stepSupervisors/StepSupervisors.vue
@@ -5,19 +5,10 @@
     >
         <!-- TODO @alain: implement -->
         <div>Step Supervisors</div>
-        <v-btn @click="handleButtonReadyClick">Ready!</v-btn>
         <div style="height: 2000px; background: salmon">
             Demo: Very long content
         </div>
     </Step>
 </template>
 
-<script setup lang="ts">
-import { useStepSupervisorsStore } from "./composables/store/useStepSupervisorsStore";
-
-const store = useStepSupervisorsStore();
-
-const handleButtonReadyClick = () => {
-    store.markAsReady();
-};
-</script>
+<script setup lang="ts"></script>

--- a/client/src/components/views/seb-server/template/exam/components/stepSupervisors/composables/store/useStepSupervisorsStore.ts
+++ b/client/src/components/views/seb-server/template/exam/components/stepSupervisors/composables/store/useStepSupervisorsStore.ts
@@ -2,15 +2,11 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 
 const initialState = {
-    isReady: false,
+    isReady: true,
 };
 
 export const useStepSupervisorsStore = defineStore("stepSupervisors", () => {
     const isReady = ref(initialState.isReady);
-
-    const markAsReady = () => {
-        isReady.value = true;
-    };
 
     const $reset = () => {
         isReady.value = initialState.isReady;
@@ -18,7 +14,6 @@ export const useStepSupervisorsStore = defineStore("stepSupervisors", () => {
 
     return {
         isReady,
-        markAsReady,
         $reset,
     };
 });

--- a/client/src/components/widgets/form/Form.vue
+++ b/client/src/components/widgets/form/Form.vue
@@ -1,5 +1,9 @@
 <template>
-    <v-form class="w-100 w-md-50" @submit.prevent>
+    <v-form
+        class="w-100 w-md-50"
+        @update:model-value="handleModelValueUpdated"
+        @submit.prevent
+    >
         <v-container fluid class="pa-0">
             <v-row
                 v-for="field in fields"
@@ -51,12 +55,19 @@
 </template>
 
 <script setup lang="ts">
+import { VForm } from "vuetify/components";
 import { useRules } from "vuetify/labs/rules";
 import {
     FormField,
     FormFieldBaseProperties,
     FormFieldTextualProperties,
 } from "./types";
+
+const isValid = defineModel<boolean | null>();
+
+defineProps<{
+    fields: FormField[];
+}>();
 
 const getBaseProperties = (field: FormField): FormFieldBaseProperties => {
     const isRequired = field.type !== "switch" && field.required;
@@ -85,7 +96,7 @@ const getSelectProperties = (field: FormField & { type: "select" }) => ({
     clearable: !field.required,
 });
 
-defineProps<{
-    fields: FormField[];
-}>();
+const handleModelValueUpdated = (value: boolean | null) => {
+    isValid.value = value;
+};
 </script>

--- a/client/src/components/widgets/form/Form.vue
+++ b/client/src/components/widgets/form/Form.vue
@@ -51,23 +51,31 @@
 </template>
 
 <script setup lang="ts">
+import { useRules } from "vuetify/labs/rules";
 import {
     FormField,
     FormFieldBaseProperties,
     FormFieldTextualProperties,
 } from "./types";
 
-const getBaseProperties = (field: FormField): FormFieldBaseProperties => ({
-    label: `${field.label}${field.type !== "switch" && field.required ? " *" : ""}`,
-    density: "compact" as const,
-    variant: "outlined" as const,
-});
+const getBaseProperties = (field: FormField): FormFieldBaseProperties => {
+    const isRequired = field.type !== "switch" && field.required;
+
+    return {
+        label: `${field.label}${isRequired ? " *" : ""}`,
+        density: "compact" as const,
+        variant: "outlined" as const,
+        rules: [
+            ...(isRequired ? [useRules().required()] : []),
+            ...(field.rules ?? []),
+        ],
+    };
+};
 
 const getTextualProperties = (
     field: FormField & { type: "text" | "textarea" | "select" },
 ): FormFieldTextualProperties => ({
     placeholder: field.placeholder,
-    required: field.required,
 });
 
 const getSelectProperties = (field: FormField & { type: "select" }) => ({

--- a/client/src/components/widgets/form/types.ts
+++ b/client/src/components/widgets/form/types.ts
@@ -5,19 +5,18 @@ type VFieldProps = InstanceType<typeof VField>["$props"];
 type VInputProps = InstanceType<typeof VInput>["$props"];
 type VTextFieldProps = InstanceType<typeof VTextField>["$props"];
 
-export type FormFieldBaseProperties = Pick<VInputProps, "label" | "density"> &
+export type FormFieldBaseProperties = Pick<
+    VInputProps,
+    "label" | "density" | "rules"
+> &
     Pick<VFieldProps, "variant">;
 
-export type FormFieldTextualProperties = Pick<
-    VTextFieldProps,
-    "placeholder"
-> & {
-    required?: boolean;
-};
+export type FormFieldTextualProperties = Pick<VTextFieldProps, "placeholder">;
 
 export type FormField = {
     name: string;
     label: string;
+    rules?: VInputProps["rules"];
 } & (
     | {
           type: "text";

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -69,6 +69,9 @@
             "EXAM_ADMIN": "Exam Administrator",
             "EXAM_SUPPORTER": "Exam Supervisor",
             "TEACHER": "Teacher"
+        },
+        "validation": {
+            "blacklisted": "Field must not be any of the following values: {values}"
         }
     },
 
@@ -236,7 +239,8 @@
                 "fields": {
                     "name": {
                         "label": "Name",
-                        "placeholder": "Enter the desired name of the exam template"
+                        "placeholder": "Enter the desired name of the exam template",
+                        "validationErrorUniqueName": "An exam template with this name already exists"
                     },
                     "description": {
                         "label": "Description",

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -11,6 +11,7 @@ import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import { aliases, mdi } from "vuetify/iconsets/mdi";
+import { createRulesPlugin } from "vuetify/labs/rules";
 
 const vuetify = createVuetify({
     components,
@@ -26,6 +27,8 @@ const app = createApp(App);
 app.use(vuetify);
 registerPlugins(app);
 app.use(i18n);
+
+app.use(createRulesPlugin({}, vuetify.locale));
 
 app.component("AlertMsg", AlertMsg);
 app.mount("#app");

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -28,7 +28,23 @@ app.use(vuetify);
 registerPlugins(app);
 app.use(i18n);
 
-app.use(createRulesPlugin({}, vuetify.locale));
+app.use(
+    createRulesPlugin(
+        {
+            aliases: {
+                blacklisted: (blacklistedValues: Set<string>, err?: string) => {
+                    return (v: string) =>
+                        !blacklistedValues.has(v) ||
+                        err ||
+                        i18n.global.t("general.validation.blacklisted", {
+                            values: Array.from(blacklistedValues).join(", "),
+                        });
+                },
+            },
+        },
+        vuetify.locale,
+    ),
+);
 
 app.component("AlertMsg", AlertMsg);
 app.mount("#app");

--- a/client/src/models/seb-server/examTemplate.ts
+++ b/client/src/models/seb-server/examTemplate.ts
@@ -32,12 +32,6 @@ type ExamAttribute = {
     quitPassword?: string; // optional, is not used yet, ignore it
 };
 
-export type ExamTemplateName = {
-    modelId: string;
-    entityType: "EXAM_TEMPLATE";
-    name: string;
-};
-
 type ExamTemplate = {
     id?: number; // PK of the ExamTemplate only available when the ExamTemplate exists
     name: string; // mandatory, min 3 - max 255 chars, name is unique for all ExamTemplate (2)

--- a/client/src/models/seb-server/examTemplate.ts
+++ b/client/src/models/seb-server/examTemplate.ts
@@ -32,6 +32,12 @@ type ExamAttribute = {
     quitPassword?: string; // optional, is not used yet, ignore it
 };
 
+export type ExamTemplateName = {
+    modelId: string;
+    entityType: "EXAM_TEMPLATE";
+    name: string;
+};
+
 type ExamTemplate = {
     id?: number; // PK of the ExamTemplate only available when the ExamTemplate exists
     name: string; // mandatory, min 3 - max 255 chars, name is unique for all ExamTemplate (2)

--- a/client/src/services/seb-server/api-services/examTemplateService.ts
+++ b/client/src/services/seb-server/api-services/examTemplateService.ts
@@ -11,14 +11,19 @@ export async function getExamTemplate(id: string): Promise<ExamTemplate | any> {
     ).data;
 }
 
-export async function getExamTemplateNames(): Promise<ExamTemplateName[]> {
+export async function getExamTemplateNames(): Promise<
+    {
+        modelId: string;
+        entityType: "EXAM_TEMPLATE";
+        name: string;
+    }[]
+> {
     return (
         await apiService.api.get(url + "/names", {
             headers: apiService.getHeaders(StorageItemEnum.ACCESS_TOKEN),
         })
     ).data;
 }
-
 export async function getExamTemplates(
     optionalParameters?: OptionalParGeneric,
 ): Promise<ExamTemplates | any> {

--- a/client/src/services/seb-server/api-services/examTemplateService.ts
+++ b/client/src/services/seb-server/api-services/examTemplateService.ts
@@ -11,6 +11,14 @@ export async function getExamTemplate(id: string): Promise<ExamTemplate | any> {
     ).data;
 }
 
+export async function getExamTemplateNames(): Promise<ExamTemplateName[]> {
+    return (
+        await apiService.api.get(url + "/names", {
+            headers: apiService.getHeaders(StorageItemEnum.ACCESS_TOKEN),
+        })
+    ).data;
+}
+
 export async function getExamTemplates(
     optionalParameters?: OptionalParGeneric,
 ): Promise<ExamTemplates | any> {


### PR DESCRIPTION
@Rad14nt This PR introduces form validation for the exam template wizard:
* Required fields are automatically validated
* Additional rules can be passed in to the generic Form component
* I've set up Vuetify's [Rules Plugin](https://vuetifyjs.com/en/features/rules/) for this
* For most of our use cases, Vuetify already has a rule for us. We should reuse those instead of defining our own rules for each input field.
* If we have to add new rules, we should add them to `createRulesPlugin` (see `main.ts`). I've added one for blacklists there. This is used to ensure that exam template names are unique (see `useFormFields` – The existing names are fetched from the API, then passed to the validator rule). 