### PR TITLE
Eslint: no undefined components

### DIFF
--- a/.claude/rules/client.md
+++ b/.claude/rules/client.md
@@ -17,6 +17,7 @@ on the filesystem if they clash:
 # Best practice
 
 - TypeScript: Avoid manual typecasts like `as FooBar`. Properly cast the types and fulfill their requirements.
+- Don't start component names with `V`. This is reserved for Vuetify by convention.
 - Prefer the "Vue composition API" over the "Vue options API".
 - Routing: when generating urls for Vuetify components with a `to` property (e.g. `v-list-item`, `v-btn`, ...), you
   must always use the `typedTo` helper function so type safety is ensured.

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -47,6 +47,13 @@ export default defineConfig([
         rules: {
             "no-console": "error",
             "no-debugger": "error",
+            "vue/no-undef-components": [
+                // Vuetify components (VBtn, VRow, ...) are auto-imported by vite-plugin-vuetify, and we
+                // don't want to enforce manual imports of Vuetify components for now. Hence we
+                // exclude them here, using the Vuetify naming convention (V + PascalCase)
+                "error",
+                { ignorePatterns: ["^V[A-Z]"] },
+            ],
         },
     },
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,7 +1,7 @@
 <template>
     <v-app>
         <ErrorMsg></ErrorMsg>
-        <router-view />
+        <RouterView />
     </v-app>
 </template>
 
@@ -10,6 +10,7 @@ import "vue-loading-overlay/dist/css/index.css";
 import "@vuepic/vue-datepicker/dist/main.css";
 import ErrorMsg from "@/components/widgets/ErrorMsg.vue";
 import { onMounted } from "vue";
+import { RouterView } from "vue-router";
 import { useTokenRefresh } from "@/composables/useTokenRefresh";
 
 onMounted(() => {

--- a/client/src/components/layout/container/ContainerAppBar.vue
+++ b/client/src/components/layout/container/ContainerAppBar.vue
@@ -51,6 +51,7 @@ import { translate } from "@/utils/generalUtils";
 import ContainerProfileMenu from "@/components/layout/container/ContainerProfileMenu.vue";
 import ContainerRouteActions from "@/components/layout/container/ContainerRouteActions.vue";
 import type { RouteLocationAsRelative } from "vue-router";
+import { RouterLink } from "vue-router";
 
 defineProps<{
     homeRoute: RouteLocationAsRelative;

--- a/client/src/components/layout/container/ContainerMainShell.vue
+++ b/client/src/components/layout/container/ContainerMainShell.vue
@@ -7,7 +7,7 @@
             ]"
             :data-testid="`${pageTestId}-page-container`"
         >
-            <router-view />
+            <RouterView />
         </div>
 
         <ToastContainer />
@@ -16,6 +16,7 @@
 
 <script setup lang="ts">
 import ToastContainer from "@/components/widgets/toast/ToastContainer.vue";
+import { RouterView } from "vue-router";
 
 defineProps<{
     isPageBlue: boolean;

--- a/client/src/components/widgets/breadCrumb/BreadCrumb.vue
+++ b/client/src/components/widgets/breadCrumb/BreadCrumb.vue
@@ -47,6 +47,7 @@
 
 <script setup lang="ts">
 import type { BreadCrumbItem } from "./types";
+import { RouterLink } from "vue-router";
 
 defineProps<{
     items?: BreadCrumbItem[];

--- a/client/src/components/widgets/navigationWidgets/NavigationItem.vue
+++ b/client/src/components/widgets/navigationWidgets/NavigationItem.vue
@@ -5,14 +5,14 @@
         />
 
         <v-list-item class="px-0 nav-hover">
-            <router-link
+            <RouterLink
                 v-if="to"
                 class="link-color nav-link"
                 :data-testid="testId"
                 :to="to"
             >
                 {{ label }}
-            </router-link>
+            </RouterLink>
 
             <span v-else class="link-color nav-link" :data-testid="testId">
                 {{ label }}
@@ -23,6 +23,7 @@
 
 <script setup lang="ts">
 import type { NavigationSectionTarget } from "@/components/widgets/navigationWidgets/types.ts";
+import { RouterLink } from "vue-router";
 
 withDefaults(
     defineProps<{

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,7 +1,6 @@
 import { createApp } from "vue";
 import App from "./App.vue";
 import { registerPlugins } from "@/plugins";
-import AlertMsg from "@/components/widgets/AlertMsg.vue";
 import i18n from "./i18n";
 
 // 🚀 Vuetify setup
@@ -38,5 +37,4 @@ app.use(
     ),
 );
 
-app.component("AlertMsg", AlertMsg);
 app.mount("#app");

--- a/client/src/pages/(app)/connection-configuration/[id]/index.vue
+++ b/client/src/pages/(app)/connection-configuration/[id]/index.vue
@@ -785,8 +785,9 @@
             </v-row>
         </v-col>
 
+        <!-- TODO @Andreas: This is a leftover from the recent refactoring of these kinds of dialogs.UploadDialog does not exist anymore. Please fix this -->
         <!-- Upload Certificate Dialog-->
-        <UploadDialog
+        <!-- <UploadDialog
             ref="uploadDialog"
             v-model="certDialog"
             name-prefix="certificates"
@@ -795,7 +796,7 @@
             :show-quit-password="false"
             :default-ext-list="['.p12', '.pfx', '.pem', '.crt', '.cer']"
             @uploaded="onCertImported"
-        />
+        /> -->
     </v-row>
 </template>
 

--- a/client/src/pages/(app)/connection-configuration/create/index.vue
+++ b/client/src/pages/(app)/connection-configuration/create/index.vue
@@ -154,8 +154,9 @@
         </template>
     </BasicSettingsPage>
 
+    <!-- TODO @Andreas: This is a leftover from the recent refactoring of these kinds of dialogs.UploadDialog does not exist anymore. Please fix this -->
     <!-- Upload Certificate Dialog -->
-    <UploadDialog
+    <!-- <UploadDialog
         ref="uploadDialog"
         v-model="certDialog"
         name-prefix="certificates"
@@ -164,7 +165,7 @@
         :show-quit-password="false"
         :default-ext-list="['.p12', '.pfx', '.pem', '.crt', '.cer']"
         @uploaded="onCertImported"
-    />
+    /> -->
 </template>
 
 <script setup lang="ts">

--- a/client/src/pages/(app)/exam/[id]/components/ExamDetailMain.vue
+++ b/client/src/pages/(app)/exam/[id]/components/ExamDetailMain.vue
@@ -906,6 +906,7 @@
 </template>
 
 <script setup lang="ts">
+import AlertMsg from "@/components/widgets/AlertMsg.vue";
 import { ref, onBeforeMount, ComputedRef, computed } from "vue";
 import { useExamStore } from "@/stores/seb-server/examStore.ts";
 import * as examService from "@/services/seb-server/examService.ts";

--- a/client/src/pages/(app)/exam/[id]/components/dialogs/client-group/AddClientGroupDialog.vue
+++ b/client/src/pages/(app)/exam/[id]/components/dialogs/client-group/AddClientGroupDialog.vue
@@ -305,6 +305,7 @@
 </template>
 
 <script setup lang="ts">
+import AlertMsg from "@/components/widgets/AlertMsg.vue";
 import { useExamStore } from "@/stores/seb-server/examStore.ts";
 import * as clientGroupService from "@/services/seb-server/clientGroupService.ts";
 import {

--- a/client/src/pages/(app)/exam/[id]/components/dialogs/client-group/EditClientGroupDialog.vue
+++ b/client/src/pages/(app)/exam/[id]/components/dialogs/client-group/EditClientGroupDialog.vue
@@ -204,6 +204,7 @@
 </template>
 
 <script setup lang="ts">
+import AlertMsg from "@/components/widgets/AlertMsg.vue";
 import { useExamStore } from "@/stores/seb-server/examStore.ts";
 import {
     ClientGroupEnum,

--- a/client/src/pages/(app)/gallery_[uuid]_[examId]/index.vue
+++ b/client/src/pages/(app)/gallery_[uuid]_[examId]/index.vue
@@ -61,6 +61,7 @@
 </template>
 
 <script setup lang="ts">
+import AlertMsg from "@/components/widgets/AlertMsg.vue";
 import { computed, onBeforeMount, onBeforeUnmount, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { useAppBarStore } from "@/stores/store";

--- a/client/src/pages/(app)/monitoring/[examId]/index.vue
+++ b/client/src/pages/(app)/monitoring/[examId]/index.vue
@@ -67,6 +67,7 @@
 </template>
 
 <script setup lang="ts">
+import AlertMsg from "@/components/widgets/AlertMsg.vue";
 import { useMonitoringStore } from "@/stores/seb-server/monitoringStore.ts";
 import MonitoringOverviewIndicators from "./components/MonitoringOverviewIndicators.vue";
 import * as indicatorService from "@/services/seb-server/indicatorService.ts";

--- a/client/src/pages/(app)/quiz-import/index.vue
+++ b/client/src/pages/(app)/quiz-import/index.vue
@@ -149,6 +149,7 @@
 </template>
 
 <script setup lang="ts">
+import AlertMsg from "@/components/widgets/AlertMsg.vue";
 import { useQuizImportStore } from "@/stores/seb-server/quizImportStore.ts";
 import { storeToRefs } from "pinia";
 import * as constants from "@/utils/constants.ts";

--- a/client/src/pages/(app)/running-sp-exams/index.vue
+++ b/client/src/pages/(app)/running-sp-exams/index.vue
@@ -97,7 +97,7 @@
                                 )
                             "
                         >
-                            <router-link
+                            <RouterLink
                                 class="default-color"
                                 :to="{
                                     name: '/(app)/gallery_[uuid]_[examId]/',
@@ -106,7 +106,7 @@
                                         examId: item.exam.uuid,
                                     },
                                 }"
-                                >{{ item.name }}</router-link
+                                >{{ item.name }}</RouterLink
                             >
                         </div>
                     </td>
@@ -125,6 +125,7 @@ import * as tableUtils from "@/utils/table/tableUtils";
 import TableHeaders from "@/utils/table/TableHeaders.vue";
 import { storeToRefs } from "pinia";
 import { Group, GroupObject } from "@/models/screen-proctoring/group";
+import { RouterLink } from "vue-router";
 
 definePage({
     meta: {

--- a/client/src/pages/(public).vue
+++ b/client/src/pages/(public).vue
@@ -1,3 +1,7 @@
 <template>
     <RouterView />
 </template>
+
+<script setup lang="ts">
+import { RouterView } from "vue-router";
+</script>

--- a/client/src/pages/(public)/login/index.vue
+++ b/client/src/pages/(public)/login/index.vue
@@ -100,7 +100,7 @@
                         <span>
                             {{ translate("loginPage.noAccount") }}
                         </span>
-                        <router-link
+                        <RouterLink
                             :to="{ name: '/(public)/register/' }"
                             class="text-primary"
                             data-testid="login-register-link"
@@ -108,7 +108,7 @@
                             tabindex="0"
                         >
                             {{ translate("loginPage.register") }}
-                        </router-link>
+                        </RouterLink>
                     </div>
                 </v-card-text>
             </v-card>
@@ -117,10 +117,12 @@
 </template>
 
 <script setup lang="ts">
+import AlertMsg from "@/components/widgets/AlertMsg.vue";
 import { ref } from "vue";
 import { useTheme } from "vuetify";
 import { translate } from "@/utils/generalUtils";
 import { useLogin } from "../composables/useLogin";
+import { RouterLink } from "vue-router";
 
 definePage({
     meta: {

--- a/client/src/pages/(public)/register/index.vue
+++ b/client/src/pages/(public)/register/index.vue
@@ -292,13 +292,13 @@
                                             )
                                         "
                                     >
-                                        <router-link
+                                        <RouterLink
                                             :to="{ name: '/(public)/login/' }"
                                             >{{
                                                 translate(
                                                     "userAccount.registerPage.buttons.login",
                                                 )
-                                            }}</router-link
+                                            }}</RouterLink
                                         >
                                     </span>
                                 </div>
@@ -320,7 +320,8 @@ import { useI18n } from "vue-i18n";
 import { Institution } from "@/models/seb-server/institution";
 import { getInstitutions } from "@/services/seb-server/institutionService.ts";
 import { registerUserAccount } from "@/services/seb-server/userAccountService.ts";
-import { useRouter } from "vue-router";
+import { RouterLink, useRouter } from "vue-router";
+import AlertMsg from "@/components/widgets/AlertMsg.vue";
 
 definePage({
     meta: {


### PR DESCRIPTION
@anhefti @Rad14nt This ensures, that we don't accidentally use components that don't exist. We now must import all components explicitly. I made an exception for Vuetify, as this would be a huge change. We might rwant emove the exception in the future, because currently we still have the problem that using an unexisting Vuetify component like "v-i-just-made-this-up", would only trigger an error at runtime.

@anhefti I tagged you in the TODOs for the cleanup of the two remaining UploadDialog useages, I hope that's ok